### PR TITLE
Add CI workflow for PR validation and merge queue support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+  merge_group:
+
+jobs:
+  validate:
+    name: Validate Theme
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - run: npm ci
+      - run: npx gulp build
+      - run: npm test


### PR DESCRIPTION
Adds a GitHub Actions CI workflow that:

- Runs `npm ci`, `npx gulp build`, and `npm test` (gscan validation) on pull requests targeting `main`
- Supports `merge_group` trigger for merge queue compatibility

This provides a required status check (`Validate Theme`) that the merge queue can gate on.